### PR TITLE
Feature/pipenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+Pipfile.lock
 # C extensions
 *.so
 
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+# Ide
+.vscode

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+ 
+
+[packages]
+
+dnspython = "2.2.1"
+
+
+[dev-packages]
+
+

--- a/README.md
+++ b/README.md
@@ -1,19 +1,26 @@
-# Kobra is a simple tool for find register dns 
+## Kobra 
 
+A simple tool for search DNS registers. 
 
+You just Python3 :snake: and pipenv
 
-You just Python 3 and run `pip -r requeriments.txt`
+## Instalation
 
-## USAGE
+You just Python3 :snake: and pipenv
+
+`pipenv install `
+
+## Usage
 
 
 Short Form    | Long Form     | Description
 ------------- | ------------- |-------------
 -i            | --input      | file from will your list with domain
--r            | --resolver  | dns name for resolver
+-r            | --resolver  | dns server for resolver
 -t            | --type      | type of dns records
 
-Create a file with domains that like know the register .
+
+Create a file with the domains that like know the register .
 
 Execute for example:
 
@@ -21,8 +28,14 @@ Execute for example:
 python3 kobra.py -i domain.txt -r 8.8.8.8 -t cname
 
 ```
-You can get a file domains with your subdomains if use [Sublist3r](https://github.com/aboul3la/Sublist3r)
 
-## LICENSE
+You could create a file of domains and subdomains with a tool like [Sublist3r](https://github.com/aboul3la/Sublist3r)
 
-[LICENSE] (https://github.com/violenti/kobra/blob/master/LICENSE)
+
+## Feature :hammer_and_wrench:	 and Bug report :bug:
+
+You can do create an [issue](https://github.com/violenti/kobra/issues), please with as much as information.  
+
+## License
+
+[LICENSE](https://github.com/violenti/kobra/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 A simple tool for search DNS registers. 
 
-You just Python3 :snake: and pipenv
 
 ## Instalation
 

--- a/kobra.py
+++ b/kobra.py
@@ -1,12 +1,13 @@
 #!/usr/bin/python3
 # -*- coding: UTF-8 -*-
 
-import socket
+#import socket
 import dns.resolver
 import dns.exception
 import time
 import argparse
 import sys
+
 
 resolver = dns.resolver.Resolver()
 print (r"""
@@ -28,11 +29,12 @@ def parse_args():
     parser.add_argument('-i', '--input', help="file from will your list with domain",type=str, required=True)
     parser.add_argument('-r','--resolver',help="dns name for resolver, for example 8.8.8.8", type=str, required=False)
     parser.add_argument('-t','--type',help="type of dns record for finding", type=str,required=False)
+
     return parser.parse_args()
 
 args = parse_args()
 
-##print domains
+
 def finddns(nameservers, domain):
     for data in nameservers :
         print (domain,"",data)
@@ -45,27 +47,24 @@ def main():
     typerecords = args.type
     nameservers= ''
     if typerecords is None:
-        print ("Please set the dns records")
+        print ("Please set the dns records")    
     else:
-
        with open(filedns,encoding='utf-8') as f:
-
            for line in f:
                domain= line.strip()
                time.sleep(3)
                if resolverdns is None:
                    try:
-                     nameservers = dns.resolver.query(domain, typerecords)
+                     nameservers = dns.resolver.resolve(domain, typerecords)
                    except dns.exception.DNSException as e:
                        print (domain,"","not register")
                else:
                   resolver=dns.resolver.Resolver(configure=False)
                   resolver.nameservers = [resolverdns]
                   try:
-                      nameservers = dns.resolver.query(domain,typerecords)
+                      nameservers = dns.resolver.resolver(domain,typerecords)
                   except dns.exception.DNSException as e:
                       print (domain,"","not register")
-
                finddns(nameservers,domain)
 
 

--- a/requeriments.txt
+++ b/requeriments.txt
@@ -1,2 +1,0 @@
-dnspython==1.16.0
-argparse==1.4.0


### PR DESCRIPTION
New version of dnspython = "2.2.1", remove argparse as dependece. Remove requirements.txt because now the project used pipenv for library. 
